### PR TITLE
README: permissively license the text itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,8 @@ That text is a [flipped form](https://flippedform.com/) in everyday English.  If
 
 ## Permission
 
-Each contributor licenses you to do everything with the Software Credit Requirement that would otherwise infringe that contributor’s copyright in it.
+Each contributor licenses you to do everything with the legal text that would otherwise infringe that contributor’s copyright in it.
+
+If you make changes to the legal text, you must remove all mention of "Credit Requirement" as well.
+
+***As far as the law allows, the legal text comes as is, without any warranty at all, and no contributor will be liable to anyone for any damages related to the text or its use, for any kind of legal claim.***

--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@ That text is a [flipped form](https://flippedform.com/) in everyday English.  If
 - [ ] Compile a registry of projects using the terms.
 
 - [ ] Submit the text to [SPDX](https://spdx.org) for standardization as a license exception.
+
+## Permission
+
+Each contributor licenses you to do everything with the Software Credit Requirement that would otherwise infringe that contributor’s copyright in it.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@ That text is a [flipped form](https://flippedform.com/) in everyday English.  If
 
 Each contributor licenses you to do everything with the legal text that would otherwise infringe that contributor’s copyright in it.
 
-If you make changes to the legal text, you must remove all mention of "Credit Requirement" as well.
+If you make changes to the legal text, you must change or remove the title "Credit Requirement".
 
 ***As far as the law allows, the legal text comes as is, without any warranty at all, and no contributor will be liable to anyone for any damages related to the text or its use, for any kind of legal claim.***


### PR DESCRIPTION
Similarly to the Blue Oak Model License, I think we should license the text itself.

1. Should we have a clause about changing the name if you change the text?
2. Should we maybe license the text itself under the CC-BY (I would say Blue Oak Model License, but that's only for software)? Maybe even some license + Software Credits requirement? That would be an awesome recursive license, but maybe too confusing.
3. Should this permission clause go in text.md instead?